### PR TITLE
Release-2 two-table tracker output: tracker_hits (reco) + tracker_simhits (truth)

### DIFF
--- a/Examples/Io/Arrow/CMakeLists.txt
+++ b/Examples/Io/Arrow/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
     ActsExamplesIoArrow_obj
     OBJECT
+    src/ArrowMeasurementOutputConverter.cpp
     src/ArrowParticleOutputConverter.cpp
     src/ArrowSimHitOutputConverter.cpp
     src/ArrowTrackOutputConverter.cpp

--- a/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp
+++ b/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp
@@ -44,11 +44,15 @@ class ACTS_ARROW_EXPORT ArrowMeasurementOutputConverter final
   struct Config {
     /// Measurement container (required). One output row per measurement.
     std::string inputMeasurements;
-    /// Cluster container parallel to the measurements (required for the
-    /// shape columns; produced by the geometric digitization).
+    /// Optional cluster container parallel to the measurements (produced by
+    /// the geometric digitization). When unset - e.g. smearing-only
+    /// digitization - the shape columns are emitted as zeros so the schema
+    /// stays stable.
     std::string inputClusters;
-    /// Input @c SimHitContainer (required; used to resolve contributing
-    /// particles for @c particle_ids).
+    /// Optional input @c SimHitContainer; must be set together with
+    /// @c inputSimHitMeasurementsMap. When unset (e.g. data, or a reco-only
+    /// conversion) the @c particle_ids / @c simhit_ids link columns are
+    /// emitted as empty lists.
     std::string inputSimHits;
     /// Optional input particle container used to resolve a contributing
     /// sim-hit's particle barcode to a row index in the corresponding parquet
@@ -56,8 +60,9 @@ class ACTS_ARROW_EXPORT ArrowMeasurementOutputConverter final
     /// consumes for that table — leaving it empty forces the unmatched
     /// sentinel.
     std::string inputParticles;
-    /// Sim-hit → measurement(s) map keyed by @c SimHitIndex (required). It is
-    /// inverted internally to measurement → contributing sim-hits.
+    /// Optional sim-hit → measurement(s) map keyed by @c SimHitIndex; must be
+    /// set together with @c inputSimHits. It is inverted internally to
+    /// measurement → contributing sim-hits.
     std::string inputSimHitMeasurementsMap;
     /// Output whiteboard key for the resulting @c arrow::Table.
     std::string outputTable = "tracker_hits";

--- a/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp
+++ b/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp
@@ -1,0 +1,104 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Geometry/GeometryIdentifier.hpp"
+#include "Acts/Geometry/TrackingGeometry.hpp"
+#include "ActsExamples/EventData/Cluster.hpp"
+#include "ActsExamples/EventData/Measurement.hpp"
+#include "ActsExamples/EventData/SimHit.hpp"
+#include "ActsExamples/EventData/SimParticle.hpp"
+#include "ActsExamples/EventData/TruthMatching.hpp"
+#include "ActsExamples/Framework/DataHandle.hpp"
+#include "ActsExamples/Io/Parquet/ArrowOutputConverter.hpp"
+#include "ActsPlugins/Arrow/ArrowUtil.hpp"
+#include "ActsPlugins/Arrow/Export.hpp"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ActsExamples {
+
+/// Convert measurements into the per-event RECO table (`tracker_hits`): one
+/// entry per measurement, the entry's position being the measurement id
+/// referenced by track `hit_ids`. Carries the measured local parameters and
+/// variances (always expanded to the full bound layout, with a `subspace`
+/// bitmask saying which components were actually measured: bit0 = loc0,
+/// bit1 = loc1, bit2 = time), the reco global position, cluster-shape
+/// features from the geometric digitization, and truth LINKS only:
+/// `particle_ids` (rows in the particle table) and `simhit_ids` (rows in the
+/// `tracker_simhits` table of the same event, see
+/// `ArrowSimHitOutputConverter`).
+class ACTS_ARROW_EXPORT ArrowMeasurementOutputConverter final
+    : public ArrowOutputConverter {
+ public:
+  struct Config {
+    /// Measurement container (required). One output row per measurement.
+    std::string inputMeasurements;
+    /// Cluster container parallel to the measurements (required for the
+    /// shape columns; produced by the geometric digitization).
+    std::string inputClusters;
+    /// Input @c SimHitContainer (required; used to resolve contributing
+    /// particles for @c particle_ids).
+    std::string inputSimHits;
+    /// Optional input particle container used to resolve a contributing
+    /// sim-hit's particle barcode to a row index in the corresponding parquet
+    /// table. Must be the same container the @c ArrowParticleOutputConverter
+    /// consumes for that table — leaving it empty forces the unmatched
+    /// sentinel.
+    std::string inputParticles;
+    /// Sim-hit → measurement(s) map keyed by @c SimHitIndex (required). It is
+    /// inverted internally to measurement → contributing sim-hits.
+    std::string inputSimHitMeasurementsMap;
+    /// Output whiteboard key for the resulting @c arrow::Table.
+    std::string outputTable = "tracker_hits";
+    /// Tracking geometry used to find surfaces by @c GeometryIdentifier when
+    /// projecting each measurement's local parameters back to global
+    /// coordinates (required).
+    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
+    /// Diagnostic only: sim-hits contributing to no measurement are absent
+    /// from this table's links (they remain in the truth table). A warning is
+    /// logged when the fraction exceeds this value.
+    double maxUnmatchedSimHitFraction = 0.001;
+    /// Resolves the @c detector subsystem id for a given geometry id.
+    /// Defaults to reading the geometry id's @c extra byte.
+    std::function<std::uint8_t(Acts::GeometryIdentifier)> detectorResolver =
+        [](Acts::GeometryIdentifier gid) {
+          return static_cast<std::uint8_t>(gid.extra());
+        };
+  };
+
+  explicit ArrowMeasurementOutputConverter(
+      const Config& cfg, std::unique_ptr<const Acts::Logger> logger = nullptr);
+
+  const Config& config() const { return m_cfg; }
+
+  std::vector<std::string> collections() const override;
+
+ private:
+  ProcessCode execute(const AlgorithmContext& ctx) const override;
+
+  Config m_cfg;
+
+  ReadDataHandle<MeasurementContainer> m_inputMeasurements{
+      this, "InputMeasurements"};
+  ReadDataHandle<ClusterContainer> m_inputClusters{this, "InputClusters"};
+  ReadDataHandle<SimHitContainer> m_inputSimHits{this, "InputSimHits"};
+  ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
+  ReadDataHandle<SimHitMeasurementsMap> m_inputSimHitMeasurementsMap{
+      this, "InputSimHitMeasurementsMap"};
+
+  WriteDataHandle<ActsPlugins::ArrowUtil::ArrowTable> m_outputTable{
+      this, "OutputTable"};
+};
+
+}  // namespace ActsExamples

--- a/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowSimHitOutputConverter.hpp
+++ b/Examples/Io/Arrow/include/ActsExamples/Io/Arrow/ArrowSimHitOutputConverter.hpp
@@ -9,11 +9,8 @@
 #pragma once
 
 #include "Acts/Geometry/GeometryIdentifier.hpp"
-#include "Acts/Geometry/TrackingGeometry.hpp"
-#include "ActsExamples/EventData/Measurement.hpp"
 #include "ActsExamples/EventData/SimHit.hpp"
 #include "ActsExamples/EventData/SimParticle.hpp"
-#include "ActsExamples/EventData/TruthMatching.hpp"
 #include "ActsExamples/Framework/DataHandle.hpp"
 #include "ActsExamples/Io/Parquet/ArrowOutputConverter.hpp"
 #include "ActsPlugins/Arrow/ArrowUtil.hpp"
@@ -28,47 +25,26 @@
 
 namespace ActsExamples {
 
-/// Convert measurements (with their contributing sim-hit truth) to an
-/// @c arrow::Table.
-///
-/// The output table has one row per event with list-valued columns, and one
-/// entry per MEASUREMENT. Measurements are emitted in @c MeasurementContainer
-/// iteration order, so the entry's position in the per-event lists equals its
-/// measurement index — downstream tables (e.g. tracks) reference measurements
-/// by that index, and there is no separate measurement-id column. Reco
-/// @c x,y,z + geometry are one value per measurement; the contributing
-/// sim-hits' truth (@c particle_id, @c true_x,true_y,true_z, @c time) are
-/// nested lists (outer = per measurement, inner = per contributing sim-hit).
-///
-/// Sim-hits that contribute to no measurement are dropped (expected to be a
-/// negligible fraction); the dropped fraction is checked at runtime against
-/// @c maxUnmatchedSimHitFraction.
+/// Convert simulated tracker hits into the per-event TRUTH table
+/// (`tracker_simhits`): one entry per sim-hit, ALL sim-hits in container
+/// order. The entry's position is the sim-hit id that the measurement table
+/// (`ArrowMeasurementOutputConverter`) references via its `simhit_ids`
+/// column. The table is standalone-complete for re-digitization: position +
+/// time, 4-momentum at the hit, deposited energy, particle link, hit index
+/// along the trajectory, and sensor identification.
 class ACTS_ARROW_EXPORT ArrowSimHitOutputConverter final
     : public ArrowOutputConverter {
  public:
   struct Config {
-    /// Input @c SimHitContainer on the whiteboard (source of truth positions
-    /// and particle barcodes for the nested per-measurement columns).
+    /// Input @c SimHitContainer on the whiteboard (required).
     std::string inputSimHits;
-    /// Optional input particle container used to resolve a contributing
-    /// sim-hit's particle barcode to a row index in the corresponding parquet
-    /// table. Must be the same container the @c ArrowParticleOutputConverter
-    /// consumes for that table — leaving it empty forces the unmatched sentinel.
+    /// Optional input particle container used to resolve a sim-hit's particle
+    /// barcode to a row index in the corresponding parquet table. Must be the
+    /// same container the @c ArrowParticleOutputConverter consumes for that
+    /// table — leaving it empty forces the unmatched sentinel.
     std::string inputParticles;
-    /// Measurement container (required). One output row per measurement.
-    std::string inputMeasurements;
-    /// Sim-hit → measurement(s) map keyed by @c SimHitIndex (required). It is
-    /// inverted internally to measurement → contributing sim-hits.
-    std::string inputSimHitMeasurementsMap;
     /// Output whiteboard key for the resulting @c arrow::Table.
-    std::string outputTable = "simhits";
-    /// Tracking geometry used to find surfaces by @c GeometryIdentifier when
-    /// projecting each measurement's local parameters back to global
-    /// coordinates (required).
-    std::shared_ptr<const Acts::TrackingGeometry> trackingGeometry;
-    /// Sim-hits contributing to no measurement are dropped from the table.
-    /// If the dropped fraction exceeds this, conversion throws (default 0.1%).
-    double maxUnmatchedSimHitFraction = 0.001;
+    std::string outputTable = "tracker_simhits";
     /// Resolves the @c detector subsystem id for a given hit's geometry id.
     /// Defaults to reading the geometry id's @c extra byte; users can swap
     /// in any custom mapping (e.g. by volume or by surface lookup) when the
@@ -102,10 +78,6 @@ class ACTS_ARROW_EXPORT ArrowSimHitOutputConverter final
 
   ReadDataHandle<SimHitContainer> m_inputSimHits{this, "InputSimHits"};
   ReadDataHandle<SimParticleContainer> m_inputParticles{this, "InputParticles"};
-  ReadDataHandle<MeasurementContainer> m_inputMeasurements{this,
-                                                           "InputMeasurements"};
-  ReadDataHandle<SimHitMeasurementsMap> m_inputSimHitMeasurementsMap{
-      this, "InputSimHitMeasurementsMap"};
 
   WriteDataHandle<ActsPlugins::ArrowUtil::ArrowTable> m_outputTable{
       this, "OutputTable"};

--- a/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
@@ -46,16 +46,11 @@ ArrowMeasurementOutputConverter::ArrowMeasurementOutputConverter(
   if (m_cfg.inputMeasurements.empty()) {
     throw std::invalid_argument("Missing measurements input collection");
   }
-  if (m_cfg.inputClusters.empty()) {
+  // Truth is optional (e.g. data, or reco-only conversions), but the sim-hit
+  // container and the sim-hit -> measurement map only make sense as a pair.
+  if (m_cfg.inputSimHits.empty() != m_cfg.inputSimHitMeasurementsMap.empty()) {
     throw std::invalid_argument(
-        "Missing clusters input collection (required for the shape columns)");
-  }
-  if (m_cfg.inputSimHits.empty()) {
-    throw std::invalid_argument("Missing sim hits input collection");
-  }
-  if (m_cfg.inputSimHitMeasurementsMap.empty()) {
-    throw std::invalid_argument(
-        "Missing sim-hit measurements map input collection");
+        "inputSimHits and inputSimHitMeasurementsMap must be set together");
   }
   if (m_cfg.outputTable.empty()) {
     throw std::invalid_argument("Missing output table name");
@@ -68,10 +63,10 @@ ArrowMeasurementOutputConverter::ArrowMeasurementOutputConverter(
   }
 
   m_inputMeasurements.initialize(m_cfg.inputMeasurements);
-  m_inputClusters.initialize(m_cfg.inputClusters);
-  m_inputSimHits.initialize(m_cfg.inputSimHits);
+  m_inputClusters.maybeInitialize(m_cfg.inputClusters);
+  m_inputSimHits.maybeInitialize(m_cfg.inputSimHits);
   m_inputParticles.maybeInitialize(m_cfg.inputParticles);
-  m_inputSimHitMeasurementsMap.initialize(m_cfg.inputSimHitMeasurementsMap);
+  m_inputSimHitMeasurementsMap.maybeInitialize(m_cfg.inputSimHitMeasurementsMap);
   m_outputTable.initialize(m_cfg.outputTable);
 }
 
@@ -82,16 +77,21 @@ std::vector<std::string> ArrowMeasurementOutputConverter::collections() const {
 ProcessCode ArrowMeasurementOutputConverter::execute(
     const AlgorithmContext& ctx) const {
   const MeasurementContainer& measurements = m_inputMeasurements(ctx);
-  const ClusterContainer& clusters = m_inputClusters(ctx);
-  const SimHitContainer& simHits = m_inputSimHits(ctx);
+  const ClusterContainer* clusters =
+      m_inputClusters.isInitialized() ? &m_inputClusters(ctx) : nullptr;
+  const SimHitContainer* simHits =
+      m_inputSimHits.isInitialized() ? &m_inputSimHits(ctx) : nullptr;
   const SimParticleContainer* particles =
       m_inputParticles.isInitialized() ? &m_inputParticles(ctx) : nullptr;
-  const SimHitMeasurementsMap& simHitMeasMap = m_inputSimHitMeasurementsMap(ctx);
+  const SimHitMeasurementsMap* simHitMeasMap =
+      m_inputSimHitMeasurementsMap.isInitialized()
+          ? &m_inputSimHitMeasurementsMap(ctx)
+          : nullptr;
 
-  if (clusters.size() != measurements.size()) {
+  if (clusters != nullptr && clusters->size() != measurements.size()) {
     throw std::runtime_error(
         "ArrowMeasurementOutputConverter: clusters (" +
-        std::to_string(clusters.size()) + ") and measurements (" +
+        std::to_string(clusters->size()) + ") and measurements (" +
         std::to_string(measurements.size()) +
         ") are not parallel containers");
   }
@@ -100,30 +100,32 @@ ProcessCode ArrowMeasurementOutputConverter::execute(
   // Sim-hits referencing no measurement stay in the truth table; here they
   // only feed a diagnostic.
   std::unordered_multimap<Index, SimHitIndex> measToSimHits;
-  measToSimHits.reserve(simHitMeasMap.size());
-  std::vector<bool> referenced(simHits.size(), false);
-  for (const auto& [simHitIdx, measIdx] : simHitMeasMap) {
-    measToSimHits.emplace(measIdx, simHitIdx);
-    if (simHitIdx < referenced.size()) {
-      referenced[simHitIdx] = true;
+  if (simHitMeasMap != nullptr) {
+    measToSimHits.reserve(simHitMeasMap->size());
+    std::vector<bool> referenced(simHits->size(), false);
+    for (const auto& [simHitIdx, measIdx] : *simHitMeasMap) {
+      measToSimHits.emplace(measIdx, simHitIdx);
+      if (simHitIdx < referenced.size()) {
+        referenced[simHitIdx] = true;
+      }
     }
-  }
-  std::size_t droppedSimHits = 0;
-  for (bool seen : referenced) {
-    if (!seen) {
-      ++droppedSimHits;
+    std::size_t droppedSimHits = 0;
+    for (bool seen : referenced) {
+      if (!seen) {
+        ++droppedSimHits;
+      }
     }
-  }
-  const double droppedFraction =
-      simHits.empty() ? 0.0
-                      : static_cast<double>(droppedSimHits) /
-                            static_cast<double>(simHits.size());
-  if (droppedFraction > m_cfg.maxUnmatchedSimHitFraction) {
-    ACTS_WARNING("ArrowMeasurementOutputConverter: "
-                 << droppedSimHits << " / " << simHits.size() << " sim-hits ("
-                 << droppedFraction * 100.0
-                 << "%) contribute to no measurement (links absent from this "
-                    "table; the hits remain in the truth table)");
+    const double droppedFraction =
+        simHits->empty() ? 0.0
+                         : static_cast<double>(droppedSimHits) /
+                               static_cast<double>(simHits->size());
+    if (droppedFraction > m_cfg.maxUnmatchedSimHitFraction) {
+      ACTS_WARNING("ArrowMeasurementOutputConverter: "
+                   << droppedSimHits << " / " << simHits->size()
+                   << " sim-hits (" << droppedFraction * 100.0
+                   << "%) contribute to no measurement (links absent from this "
+                      "table; the hits remain in the truth table)");
+    }
   }
 
   auto* pool = arrow::default_memory_pool();
@@ -302,8 +304,11 @@ ProcessCode ArrowMeasurementOutputConverter::execute(
     layV->UnsafeAppend(static_cast<std::uint16_t>(gid.layer()));
     surfV->UnsafeAppend(static_cast<std::uint32_t>(gid.sensitive()));
 
-    // Cluster-shape features (parallel container, checked above).
-    const Cluster& clu = clusters[measIdx];
+    // Cluster-shape features (parallel container, checked above). Without a
+    // clusters input the shape columns are zeros - the schema stays stable.
+    static const Cluster kEmptyCluster{};
+    const Cluster& clu =
+        clusters != nullptr ? (*clusters)[measIdx] : kEmptyCluster;
     sz0V->UnsafeAppend(clampU16(clu.sizeLoc0));
     sz1V->UnsafeAppend(clampU16(clu.sizeLoc1));
     nchV->UnsafeAppend(clampU16(clu.channels.size()));
@@ -329,8 +334,8 @@ ProcessCode ArrowMeasurementOutputConverter::execute(
       shidVV->UnsafeAppend(static_cast<std::uint32_t>(simHitIdx));
 
       std::uint64_t pid = kUnmatched;
-      if (particles != nullptr) {
-        const auto& hit = *simHits.nth(simHitIdx);
+      if (particles != nullptr && simHits != nullptr) {
+        const auto& hit = *simHits->nth(simHitIdx);
         auto pIt = particles->find(hit.particleId());
         if (pIt != particles->end()) {
           pid = static_cast<std::uint64_t>(

--- a/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
@@ -1,0 +1,353 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp"
+
+#include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/Definitions/Units.hpp"
+#include "Acts/Surfaces/RegularSurface.hpp"
+#include "Acts/Surfaces/Surface.hpp"
+#include "Acts/Utilities/Logger.hpp"
+#include "ActsExamples/EventData/Index.hpp"
+#include "ActsPlugins/Arrow/ArrowUtil.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
+
+#include <arrow/api.h>
+
+namespace ActsExamples {
+
+namespace {
+
+void check(const arrow::Status& s, const char* what) {
+  if (!s.ok()) {
+    throw std::runtime_error(std::string(what) + ": " + s.ToString());
+  }
+}
+
+}  // namespace
+
+ArrowMeasurementOutputConverter::ArrowMeasurementOutputConverter(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : ArrowOutputConverter("ArrowMeasurementOutputConverter",
+                           std::move(logger)),
+      m_cfg(cfg) {
+  if (m_cfg.inputMeasurements.empty()) {
+    throw std::invalid_argument("Missing measurements input collection");
+  }
+  if (m_cfg.inputClusters.empty()) {
+    throw std::invalid_argument(
+        "Missing clusters input collection (required for the shape columns)");
+  }
+  if (m_cfg.inputSimHits.empty()) {
+    throw std::invalid_argument("Missing sim hits input collection");
+  }
+  if (m_cfg.inputSimHitMeasurementsMap.empty()) {
+    throw std::invalid_argument(
+        "Missing sim-hit measurements map input collection");
+  }
+  if (m_cfg.outputTable.empty()) {
+    throw std::invalid_argument("Missing output table name");
+  }
+  if (m_cfg.trackingGeometry == nullptr) {
+    throw std::invalid_argument("trackingGeometry must be set");
+  }
+  if (!m_cfg.detectorResolver) {
+    throw std::invalid_argument("detectorResolver must be set");
+  }
+
+  m_inputMeasurements.initialize(m_cfg.inputMeasurements);
+  m_inputClusters.initialize(m_cfg.inputClusters);
+  m_inputSimHits.initialize(m_cfg.inputSimHits);
+  m_inputParticles.maybeInitialize(m_cfg.inputParticles);
+  m_inputSimHitMeasurementsMap.initialize(m_cfg.inputSimHitMeasurementsMap);
+  m_outputTable.initialize(m_cfg.outputTable);
+}
+
+std::vector<std::string> ArrowMeasurementOutputConverter::collections() const {
+  return {m_cfg.outputTable};
+}
+
+ProcessCode ArrowMeasurementOutputConverter::execute(
+    const AlgorithmContext& ctx) const {
+  const MeasurementContainer& measurements = m_inputMeasurements(ctx);
+  const ClusterContainer& clusters = m_inputClusters(ctx);
+  const SimHitContainer& simHits = m_inputSimHits(ctx);
+  const SimParticleContainer* particles =
+      m_inputParticles.isInitialized() ? &m_inputParticles(ctx) : nullptr;
+  const SimHitMeasurementsMap& simHitMeasMap = m_inputSimHitMeasurementsMap(ctx);
+
+  if (clusters.size() != measurements.size()) {
+    throw std::runtime_error(
+        "ArrowMeasurementOutputConverter: clusters (" +
+        std::to_string(clusters.size()) + ") and measurements (" +
+        std::to_string(measurements.size()) +
+        ") are not parallel containers");
+  }
+
+  // Invert the sim-hit -> measurement map into measurement -> sim-hits.
+  // Sim-hits referencing no measurement stay in the truth table; here they
+  // only feed a diagnostic.
+  std::unordered_multimap<Index, SimHitIndex> measToSimHits;
+  measToSimHits.reserve(simHitMeasMap.size());
+  std::vector<bool> referenced(simHits.size(), false);
+  for (const auto& [simHitIdx, measIdx] : simHitMeasMap) {
+    measToSimHits.emplace(measIdx, simHitIdx);
+    if (simHitIdx < referenced.size()) {
+      referenced[simHitIdx] = true;
+    }
+  }
+  std::size_t droppedSimHits = 0;
+  for (bool seen : referenced) {
+    if (!seen) {
+      ++droppedSimHits;
+    }
+  }
+  const double droppedFraction =
+      simHits.empty() ? 0.0
+                      : static_cast<double>(droppedSimHits) /
+                            static_cast<double>(simHits.size());
+  if (droppedFraction > m_cfg.maxUnmatchedSimHitFraction) {
+    ACTS_WARNING("ArrowMeasurementOutputConverter: "
+                 << droppedSimHits << " / " << simHits.size() << " sim-hits ("
+                 << droppedFraction * 100.0
+                 << "%) contribute to no measurement (links absent from this "
+                    "table; the hits remain in the truth table)");
+  }
+
+  auto* pool = arrow::default_memory_pool();
+
+  // Flat per-measurement columns. (Arrow builders are neither copyable nor
+  // movable, so each is constructed in place.)
+  arrow::ListBuilder loc0List(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder loc1List(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder vl0List(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder vl1List(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder timeList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder vtList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder subList(pool, std::make_shared<arrow::UInt8Builder>(pool));
+  arrow::ListBuilder xList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder yList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder zList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder detList(pool, std::make_shared<arrow::UInt8Builder>(pool));
+  arrow::ListBuilder volList(pool, std::make_shared<arrow::UInt8Builder>(pool));
+  arrow::ListBuilder layList(pool,
+                             std::make_shared<arrow::UInt16Builder>(pool));
+  arrow::ListBuilder surfList(pool,
+                              std::make_shared<arrow::UInt32Builder>(pool));
+  arrow::ListBuilder sz0List(pool,
+                             std::make_shared<arrow::UInt16Builder>(pool));
+  arrow::ListBuilder sz1List(pool,
+                             std::make_shared<arrow::UInt16Builder>(pool));
+  arrow::ListBuilder nchList(pool,
+                             std::make_shared<arrow::UInt16Builder>(pool));
+  arrow::ListBuilder sumList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder letaList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder lphiList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder getaList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder gphiList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder eangList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder pangList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+
+  // Nested truth-link columns: outer = per measurement, inner = per
+  // contributing sim-hit.
+  auto pidInner = std::make_shared<arrow::ListBuilder>(
+      pool, std::make_shared<arrow::UInt64Builder>(pool));
+  auto shidInner = std::make_shared<arrow::ListBuilder>(
+      pool, std::make_shared<arrow::UInt32Builder>(pool));
+  arrow::ListBuilder pidList(pool, pidInner);
+  arrow::ListBuilder shidList(pool, shidInner);
+
+  std::vector<arrow::ListBuilder*> all = {
+      &loc0List, &loc1List, &vl0List, &vl1List, &timeList, &vtList,
+      &subList,  &xList,    &yList,   &zList,   &detList,  &volList,
+      &layList,  &surfList, &sz0List, &sz1List, &nchList,  &sumList,
+      &letaList, &lphiList, &getaList, &gphiList, &eangList, &pangList,
+      &pidList,  &shidList};
+  for (auto* b : all) {
+    check(b->Append(), "open per-event list");
+  }
+
+  auto fv = [](arrow::ListBuilder& b) {
+    return static_cast<arrow::FloatBuilder*>(b.value_builder());
+  };
+  auto* loc0V = fv(loc0List);
+  auto* loc1V = fv(loc1List);
+  auto* vl0V = fv(vl0List);
+  auto* vl1V = fv(vl1List);
+  auto* timeV = fv(timeList);
+  auto* vtV = fv(vtList);
+  auto* subV = static_cast<arrow::UInt8Builder*>(subList.value_builder());
+  auto* xV = fv(xList);
+  auto* yV = fv(yList);
+  auto* zV = fv(zList);
+  auto* detV = static_cast<arrow::UInt8Builder*>(detList.value_builder());
+  auto* volV = static_cast<arrow::UInt8Builder*>(volList.value_builder());
+  auto* layV = static_cast<arrow::UInt16Builder*>(layList.value_builder());
+  auto* surfV = static_cast<arrow::UInt32Builder*>(surfList.value_builder());
+  auto* sz0V = static_cast<arrow::UInt16Builder*>(sz0List.value_builder());
+  auto* sz1V = static_cast<arrow::UInt16Builder*>(sz1List.value_builder());
+  auto* nchV = static_cast<arrow::UInt16Builder*>(nchList.value_builder());
+  auto* sumV = fv(sumList);
+  auto* letaV = fv(letaList);
+  auto* lphiV = fv(lphiList);
+  auto* getaV = fv(getaList);
+  auto* gphiV = fv(gphiList);
+  auto* eangV = fv(eangList);
+  auto* pangV = fv(pangList);
+
+  auto* pidVL = static_cast<arrow::ListBuilder*>(pidList.value_builder());
+  auto* shidVL = static_cast<arrow::ListBuilder*>(shidList.value_builder());
+  auto* pidVV = static_cast<arrow::UInt64Builder*>(pidVL->value_builder());
+  auto* shidVV = static_cast<arrow::UInt32Builder*>(shidVL->value_builder());
+
+  constexpr std::uint64_t kUnmatched =
+      std::numeric_limits<std::uint64_t>::max();
+  constexpr float kNaN = std::numeric_limits<float>::quiet_NaN();
+
+  auto clampU16 = [](std::size_t v) {
+    return static_cast<std::uint16_t>(
+        std::min<std::size_t>(v, std::numeric_limits<std::uint16_t>::max()));
+  };
+
+  const std::size_t nMeas = measurements.size();
+  for (Index measIdx = 0; measIdx < nMeas; ++measIdx) {
+    const auto meas = measurements.getMeasurement(measIdx);
+    const auto gid = meas.geometryId();
+
+    // Local parameters/variances, expanded to the stable full bound layout.
+    // The subspace bitmask records which components were actually measured.
+    const auto full = meas.fullParameters();
+    const auto cov = meas.fullCovariance();
+    loc0V->UnsafeAppend(static_cast<float>(full[Acts::eBoundLoc0] /
+                                           Acts::UnitConstants::mm));
+    loc1V->UnsafeAppend(static_cast<float>(full[Acts::eBoundLoc1] /
+                                           Acts::UnitConstants::mm));
+    vl0V->UnsafeAppend(static_cast<float>(
+        cov(Acts::eBoundLoc0, Acts::eBoundLoc0) /
+        (Acts::UnitConstants::mm * Acts::UnitConstants::mm)));
+    vl1V->UnsafeAppend(static_cast<float>(
+        cov(Acts::eBoundLoc1, Acts::eBoundLoc1) /
+        (Acts::UnitConstants::mm * Acts::UnitConstants::mm)));
+    timeV->UnsafeAppend(static_cast<float>(full[Acts::eBoundTime] /
+                                           Acts::UnitConstants::mm));
+    vtV->UnsafeAppend(static_cast<float>(
+        cov(Acts::eBoundTime, Acts::eBoundTime) /
+        (Acts::UnitConstants::mm * Acts::UnitConstants::mm)));
+
+    std::uint8_t subspace = 0;
+    if (meas.contains(Acts::eBoundLoc0)) {
+      subspace |= 1u;
+    }
+    if (meas.contains(Acts::eBoundLoc1)) {
+      subspace |= 2u;
+    }
+    if (meas.contains(Acts::eBoundTime)) {
+      subspace |= 4u;
+    }
+    subV->UnsafeAppend(subspace);
+
+    // Reco (digitized) global position: project the measurement's bound
+    // parameters through its surface. NaN for non-regular surfaces.
+    float gx = kNaN;
+    float gy = kNaN;
+    float gz = kNaN;
+    const Acts::Surface* surface = m_cfg.trackingGeometry->findSurface(gid);
+    if (surface == nullptr) {
+      throw std::runtime_error(
+          "ArrowMeasurementOutputConverter: surface not found for geometry "
+          "id " +
+          std::to_string(gid.value()));
+    }
+    if (const auto* regular =
+            dynamic_cast<const Acts::RegularSurface*>(surface)) {
+      Acts::Vector2 loc{full[Acts::eBoundLoc0], full[Acts::eBoundLoc1]};
+      const Acts::Vector3 global = regular->localToGlobal(ctx.geoContext, loc);
+      gx = static_cast<float>(global.x() / Acts::UnitConstants::mm);
+      gy = static_cast<float>(global.y() / Acts::UnitConstants::mm);
+      gz = static_cast<float>(global.z() / Acts::UnitConstants::mm);
+    }
+    xV->UnsafeAppend(gx);
+    yV->UnsafeAppend(gy);
+    zV->UnsafeAppend(gz);
+
+    detV->UnsafeAppend(m_cfg.detectorResolver(gid));
+    volV->UnsafeAppend(static_cast<std::uint8_t>(gid.volume()));
+    layV->UnsafeAppend(static_cast<std::uint16_t>(gid.layer()));
+    surfV->UnsafeAppend(static_cast<std::uint32_t>(gid.sensitive()));
+
+    // Cluster-shape features (parallel container, checked above).
+    const Cluster& clu = clusters[measIdx];
+    sz0V->UnsafeAppend(clampU16(clu.sizeLoc0));
+    sz1V->UnsafeAppend(clampU16(clu.sizeLoc1));
+    nchV->UnsafeAppend(clampU16(clu.channels.size()));
+    sumV->UnsafeAppend(static_cast<float>(clu.sumActivations()));
+    letaV->UnsafeAppend(clu.localEta);
+    lphiV->UnsafeAppend(clu.localPhi);
+    getaV->UnsafeAppend(clu.globalEta);
+    gphiV->UnsafeAppend(clu.globalPhi);
+    eangV->UnsafeAppend(clu.etaAngle);
+    pangV->UnsafeAppend(clu.phiAngle);
+
+    // Truth links: contributing sim-hits (row indices into the truth table)
+    // and their particles (row indices into the particle table).
+    check(pidVL->Append(), "open per-measurement particle_ids list");
+    check(shidVL->Append(), "open per-measurement simhit_ids list");
+    auto range = measToSimHits.equal_range(measIdx);
+    const auto nContribs =
+        static_cast<std::int64_t>(std::distance(range.first, range.second));
+    check(pidVV->Reserve(nContribs), "reserve particle_ids contribs");
+    check(shidVV->Reserve(nContribs), "reserve simhit_ids contribs");
+    for (auto it = range.first; it != range.second; ++it) {
+      const SimHitIndex simHitIdx = it->second;
+      shidVV->UnsafeAppend(static_cast<std::uint32_t>(simHitIdx));
+
+      std::uint64_t pid = kUnmatched;
+      if (particles != nullptr) {
+        const auto& hit = *simHits.nth(simHitIdx);
+        auto pIt = particles->find(hit.particleId());
+        if (pIt != particles->end()) {
+          pid = static_cast<std::uint64_t>(
+              std::distance(particles->begin(), pIt));
+        }
+      }
+      pidVV->UnsafeAppend(pid);
+    }
+
+  }
+
+  auto finish = [](arrow::ListBuilder& b) {
+    std::shared_ptr<arrow::Array> out;
+    check(b.Finish(&out), "finish list");
+    return out;
+  };
+
+  std::vector<std::shared_ptr<arrow::Array>> arrays = {
+      finish(loc0List), finish(loc1List), finish(vl0List),  finish(vl1List),
+      finish(timeList), finish(vtList),   finish(subList),  finish(xList),
+      finish(yList),    finish(zList),    finish(detList),  finish(volList),
+      finish(layList),  finish(surfList), finish(sz0List),  finish(sz1List),
+      finish(nchList),  finish(sumList),  finish(letaList), finish(lphiList),
+      finish(getaList), finish(gphiList), finish(eangList), finish(pangList),
+      finish(pidList),  finish(shidList),
+  };
+
+  auto table =
+      arrow::Table::Make(ActsPlugins::ArrowUtil::measurementSchema(), arrays);
+  m_outputTable(ctx, ActsPlugins::ArrowUtil::ArrowTable{std::move(table)});
+
+  return ProcessCode::SUCCESS;
+}
+
+}  // namespace ActsExamples

--- a/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowMeasurementOutputConverter.cpp
@@ -222,6 +222,21 @@ ProcessCode ArrowMeasurementOutputConverter::execute(
   };
 
   const std::size_t nMeas = measurements.size();
+  // Reserve every flat value builder before the UnsafeAppend loop — without
+  // this, UnsafeAppend writes past the buffer (heap corruption, not a clean
+  // failure).
+  for (auto* fb : {loc0V, loc1V, vl0V, vl1V, timeV, vtV, xV, yV, zV, sumV,
+                   letaV, lphiV, getaV, gphiV, eangV, pangV}) {
+    check(fb->Reserve(nMeas), "reserve float column");
+  }
+  check(subV->Reserve(nMeas), "reserve subspace");
+  check(detV->Reserve(nMeas), "reserve detector");
+  check(volV->Reserve(nMeas), "reserve volume_id");
+  for (auto* ub : {layV, sz0V, sz1V, nchV}) {
+    check(ub->Reserve(nMeas), "reserve uint16 column");
+  }
+  check(surfV->Reserve(nMeas), "reserve surface_id");
+
   for (Index measIdx = 0; measIdx < nMeas; ++measIdx) {
     const auto meas = measurements.getMeasurement(measIdx);
     const auto gid = meas.geometryId();

--- a/Examples/Io/Arrow/src/ArrowSimHitOutputConverter.cpp
+++ b/Examples/Io/Arrow/src/ArrowSimHitOutputConverter.cpp
@@ -8,16 +8,11 @@
 
 #include "ActsExamples/Io/Arrow/ArrowSimHitOutputConverter.hpp"
 
-#include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
-#include "Acts/Surfaces/RegularSurface.hpp"
-#include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/Logger.hpp"
-#include "ActsExamples/EventData/Index.hpp"
 #include "ActsPlugins/Arrow/ArrowUtil.hpp"
 
 #include <array>
-#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -53,22 +48,8 @@ ArrowSimHitOutputConverter::ArrowSimHitOutputConverter(
     throw std::invalid_argument("detectorResolver must be set");
   }
 
-  // v2 emits one row per measurement, so the measurement container, the
-  // sim-hit -> measurement map (inverted internally), and the tracking
-  // geometry (for the reco position) are all required.
-  if (m_cfg.inputMeasurements.empty() ||
-      m_cfg.inputSimHitMeasurementsMap.empty() ||
-      m_cfg.trackingGeometry == nullptr) {
-    throw std::invalid_argument(
-        "ArrowSimHitOutputConverter: inputMeasurements, "
-        "inputSimHitMeasurementsMap, and trackingGeometry are required (one "
-        "row per measurement)");
-  }
-
   m_inputSimHits.initialize(m_cfg.inputSimHits);
   m_inputParticles.maybeInitialize(m_cfg.inputParticles);
-  m_inputMeasurements.initialize(m_cfg.inputMeasurements);
-  m_inputSimHitMeasurementsMap.initialize(m_cfg.inputSimHitMeasurementsMap);
   m_outputTable.initialize(m_cfg.outputTable);
 }
 
@@ -104,56 +85,25 @@ ProcessCode ArrowSimHitOutputConverter::execute(
   const SimHitContainer& simHits = m_inputSimHits(ctx);
   const SimParticleContainer* particles =
       m_inputParticles.isInitialized() ? &m_inputParticles(ctx) : nullptr;
-  const MeasurementContainer& measurements = m_inputMeasurements(ctx);
-  const SimHitMeasurementsMap& simHitMeasMap = m_inputSimHitMeasurementsMap(ctx);
-
-  // Invert the sim-hit -> measurement map into measurement -> sim-hits, and
-  // record which sim-hits contribute to a measurement (the rest are dropped
-  // from the v2 table and counted for the diagnostic below).
-  std::unordered_multimap<Index, SimHitIndex> measToSimHits;
-  measToSimHits.reserve(simHitMeasMap.size());
-  std::vector<bool> referenced(simHits.size(), false);
-  for (const auto& [simHitIdx, measIdx] : simHitMeasMap) {
-    measToSimHits.emplace(measIdx, simHitIdx);
-    if (simHitIdx < referenced.size()) {
-      referenced[simHitIdx] = true;
-    }
-  }
-
-  // Diagnostic: sim-hits belonging to no measurement are dropped from v2. This
-  // is expected to be a tiny fraction (<0.01%); warn always and fail if it
-  // exceeds the configured threshold, so a regression can't silently grow.
-  const std::size_t totalSimHits = simHits.size();
-  std::size_t droppedSimHits = 0;
-  for (bool seen : referenced) {
-    if (!seen) {
-      ++droppedSimHits;
-    }
-  }
-  const double droppedFraction =
-      totalSimHits > 0
-          ? static_cast<double>(droppedSimHits) / static_cast<double>(totalSimHits)
-          : 0.0;
-  if (droppedSimHits > 0) {
-    ACTS_WARNING("ArrowSimHitOutputConverter: "
-                 << droppedSimHits << " / " << totalSimHits << " sim-hits ("
-                 << droppedFraction * 100.0
-                 << "%) belong to no measurement and were dropped from the "
-                    "measurement table");
-  }
-  if (droppedFraction > m_cfg.maxUnmatchedSimHitFraction) {
-    throw std::runtime_error(
-        "ArrowSimHitOutputConverter: dropped sim-hit fraction " +
-        std::to_string(droppedFraction) + " exceeds threshold " +
-        std::to_string(m_cfg.maxUnmatchedSimHitFraction));
-  }
 
   auto* pool = arrow::default_memory_pool();
 
-  // Flat columns: one value per measurement.
-  arrow::ListBuilder xList(pool, std::make_shared<arrow::FloatBuilder>(pool));
-  arrow::ListBuilder yList(pool, std::make_shared<arrow::FloatBuilder>(pool));
-  arrow::ListBuilder zList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  // Truth table: one entry per sim-hit, ALL sim-hits in container order. The
+  // entry's position is the sim-hit id that the measurement table references
+  // via simhit_ids.
+  arrow::ListBuilder txList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder tyList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder tzList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder ttList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder tpxList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder tpyList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder tpzList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder teList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder deList(pool, std::make_shared<arrow::FloatBuilder>(pool));
+  arrow::ListBuilder pidList(pool,
+                             std::make_shared<arrow::UInt64Builder>(pool));
+  arrow::ListBuilder hidxList(pool,
+                              std::make_shared<arrow::UInt16Builder>(pool));
   arrow::ListBuilder detList(pool, std::make_shared<arrow::UInt8Builder>(pool));
   arrow::ListBuilder volList(pool, std::make_shared<arrow::UInt8Builder>(pool));
   arrow::ListBuilder layList(pool,
@@ -161,148 +111,89 @@ ProcessCode ArrowSimHitOutputConverter::execute(
   arrow::ListBuilder surfList(pool,
                               std::make_shared<arrow::UInt32Builder>(pool));
 
-  // Nested truth columns: outer = per measurement, inner = per contributing
-  // sim-hit (mirrors the calo contrib_* columns).
-  auto pidInner = std::make_shared<arrow::ListBuilder>(
-      pool, std::make_shared<arrow::UInt64Builder>(pool));
-  auto txInner = std::make_shared<arrow::ListBuilder>(
-      pool, std::make_shared<arrow::FloatBuilder>(pool));
-  auto tyInner = std::make_shared<arrow::ListBuilder>(
-      pool, std::make_shared<arrow::FloatBuilder>(pool));
-  auto tzInner = std::make_shared<arrow::ListBuilder>(
-      pool, std::make_shared<arrow::FloatBuilder>(pool));
-  auto timeInner = std::make_shared<arrow::ListBuilder>(
-      pool, std::make_shared<arrow::FloatBuilder>(pool));
-  arrow::ListBuilder pidList(pool, pidInner);
-  arrow::ListBuilder txList(pool, txInner);
-  arrow::ListBuilder tyList(pool, tyInner);
-  arrow::ListBuilder tzList(pool, tzInner);
-  arrow::ListBuilder timeList(pool, timeInner);
+  std::array<arrow::ListBuilder*, 15> all = {
+      &txList,  &tyList,  &tzList, &ttList,   &tpxList,
+      &tpyList, &tpzList, &teList, &deList,   &pidList,
+      &hidxList, &detList, &volList, &layList, &surfList};
+  for (auto* b : all) {
+    check(b->Append(), "open per-event list");
+  }
 
-  // Open the per-event (outer) list on every column once.
-  check(xList.Append(), "open x list");
-  check(yList.Append(), "open y list");
-  check(zList.Append(), "open z list");
-  check(detList.Append(), "open detector list");
-  check(volList.Append(), "open volume_id list");
-  check(layList.Append(), "open layer_id list");
-  check(surfList.Append(), "open surface_id list");
-  check(pidList.Append(), "open particle_id list");
-  check(txList.Append(), "open true_x list");
-  check(tyList.Append(), "open true_y list");
-  check(tzList.Append(), "open true_z list");
-  check(timeList.Append(), "open time list");
-
-  auto* xV = static_cast<arrow::FloatBuilder*>(xList.value_builder());
-  auto* yV = static_cast<arrow::FloatBuilder*>(yList.value_builder());
-  auto* zV = static_cast<arrow::FloatBuilder*>(zList.value_builder());
+  auto* txV = static_cast<arrow::FloatBuilder*>(txList.value_builder());
+  auto* tyV = static_cast<arrow::FloatBuilder*>(tyList.value_builder());
+  auto* tzV = static_cast<arrow::FloatBuilder*>(tzList.value_builder());
+  auto* ttV = static_cast<arrow::FloatBuilder*>(ttList.value_builder());
+  auto* tpxV = static_cast<arrow::FloatBuilder*>(tpxList.value_builder());
+  auto* tpyV = static_cast<arrow::FloatBuilder*>(tpyList.value_builder());
+  auto* tpzV = static_cast<arrow::FloatBuilder*>(tpzList.value_builder());
+  auto* teV = static_cast<arrow::FloatBuilder*>(teList.value_builder());
+  auto* deV = static_cast<arrow::FloatBuilder*>(deList.value_builder());
+  auto* pidV = static_cast<arrow::UInt64Builder*>(pidList.value_builder());
+  auto* hidxV = static_cast<arrow::UInt16Builder*>(hidxList.value_builder());
   auto* detV = static_cast<arrow::UInt8Builder*>(detList.value_builder());
   auto* volV = static_cast<arrow::UInt8Builder*>(volList.value_builder());
   auto* layV = static_cast<arrow::UInt16Builder*>(layList.value_builder());
   auto* surfV = static_cast<arrow::UInt32Builder*>(surfList.value_builder());
 
-  auto* pidVL = static_cast<arrow::ListBuilder*>(pidList.value_builder());
-  auto* txVL = static_cast<arrow::ListBuilder*>(txList.value_builder());
-  auto* tyVL = static_cast<arrow::ListBuilder*>(tyList.value_builder());
-  auto* tzVL = static_cast<arrow::ListBuilder*>(tzList.value_builder());
-  auto* timeVL = static_cast<arrow::ListBuilder*>(timeList.value_builder());
-  auto* pidVV = static_cast<arrow::UInt64Builder*>(pidVL->value_builder());
-  auto* txVV = static_cast<arrow::FloatBuilder*>(txVL->value_builder());
-  auto* tyVV = static_cast<arrow::FloatBuilder*>(tyVL->value_builder());
-  auto* tzVV = static_cast<arrow::FloatBuilder*>(tzVL->value_builder());
-  auto* timeVV = static_cast<arrow::FloatBuilder*>(timeVL->value_builder());
-
-  const std::size_t nMeas = measurements.size();
-  check(xV->Reserve(nMeas), "reserve x");
-  check(yV->Reserve(nMeas), "reserve y");
-  check(zV->Reserve(nMeas), "reserve z");
-  check(detV->Reserve(nMeas), "reserve detector");
-  check(volV->Reserve(nMeas), "reserve volume_id");
-  check(layV->Reserve(nMeas), "reserve layer_id");
-  check(surfV->Reserve(nMeas), "reserve surface_id");
+  const std::size_t nHits = simHits.size();
+  check(txV->Reserve(nHits), "reserve true_x");
+  check(tyV->Reserve(nHits), "reserve true_y");
+  check(tzV->Reserve(nHits), "reserve true_z");
+  check(ttV->Reserve(nHits), "reserve true_time");
+  check(tpxV->Reserve(nHits), "reserve tpx");
+  check(tpyV->Reserve(nHits), "reserve tpy");
+  check(tpzV->Reserve(nHits), "reserve tpz");
+  check(teV->Reserve(nHits), "reserve tE");
+  check(deV->Reserve(nHits), "reserve dE");
+  check(pidV->Reserve(nHits), "reserve particle_id");
+  check(hidxV->Reserve(nHits), "reserve hit_index");
+  check(detV->Reserve(nHits), "reserve detector");
+  check(volV->Reserve(nHits), "reserve volume_id");
+  check(layV->Reserve(nHits), "reserve layer_id");
+  check(surfV->Reserve(nHits), "reserve surface_id");
 
   constexpr std::uint64_t kUnmatched =
       std::numeric_limits<std::uint64_t>::max();
-  constexpr float kNaN = std::numeric_limits<float>::quiet_NaN();
+  constexpr std::uint16_t kNoIndex = std::numeric_limits<std::uint16_t>::max();
 
-  for (Index measIdx = 0; measIdx < nMeas; ++measIdx) {
-    const auto meas = measurements.getMeasurement(measIdx);
-    const auto gid = meas.geometryId();
+  for (const auto& hit : simHits) {
+    const auto& pos = hit.fourPosition();
+    txV->UnsafeAppend(static_cast<float>(pos.x() / Acts::UnitConstants::mm));
+    tyV->UnsafeAppend(static_cast<float>(pos.y() / Acts::UnitConstants::mm));
+    tzV->UnsafeAppend(static_cast<float>(pos.z() / Acts::UnitConstants::mm));
+    ttV->UnsafeAppend(static_cast<float>(pos.w() / Acts::UnitConstants::mm));
 
-    // Reco (digitized) global position: project the measurement's bound
-    // parameters through its surface. NaN for non-regular surfaces.
-    float gx = kNaN;
-    float gy = kNaN;
-    float gz = kNaN;
-    const Acts::Surface* surface = m_cfg.trackingGeometry->findSurface(gid);
-    if (surface == nullptr) {
-      throw std::runtime_error(
-          "ArrowSimHitOutputConverter: surface not found for geometry id " +
-          std::to_string(gid.value()));
+    const auto& mom = hit.momentum4Before();
+    tpxV->UnsafeAppend(static_cast<float>(mom.x() / Acts::UnitConstants::GeV));
+    tpyV->UnsafeAppend(static_cast<float>(mom.y() / Acts::UnitConstants::GeV));
+    tpzV->UnsafeAppend(static_cast<float>(mom.z() / Acts::UnitConstants::GeV));
+    teV->UnsafeAppend(static_cast<float>(mom.w() / Acts::UnitConstants::GeV));
+    deV->UnsafeAppend(
+        static_cast<float>(hit.depositedEnergy() / Acts::UnitConstants::GeV));
+
+    std::uint64_t pid = kUnmatched;
+    if (particles != nullptr) {
+      auto pIt = particles->find(hit.particleId());
+      if (pIt != particles->end()) {
+        pid =
+            static_cast<std::uint64_t>(std::distance(particles->begin(), pIt));
+      }
     }
-    if (const auto* regular =
-            dynamic_cast<const Acts::RegularSurface*>(surface)) {
-      // Expand the (possibly 1D) measurement to a full bound vector so local
-      // positions are read from a stable layout regardless of the measured
-      // subspace.
-      const auto full = meas.fullParameters();
-      Acts::Vector2 loc{full[Acts::eBoundLoc0], full[Acts::eBoundLoc1]};
-      const Acts::Vector3 global = regular->localToGlobal(ctx.geoContext, loc);
-      gx = static_cast<float>(global.x() / Acts::UnitConstants::mm);
-      gy = static_cast<float>(global.y() / Acts::UnitConstants::mm);
-      gz = static_cast<float>(global.z() / Acts::UnitConstants::mm);
-    }
-    xV->UnsafeAppend(gx);
-    yV->UnsafeAppend(gy);
-    zV->UnsafeAppend(gz);
+    pidV->UnsafeAppend(pid);
 
+    // Hit index along the particle trajectory (ordering for consumers); -1
+    // (unset) maps to the uint16 sentinel.
+    const std::int32_t idx = hit.index();
+    hidxV->UnsafeAppend(
+        (idx < 0 || idx > static_cast<std::int32_t>(kNoIndex))
+            ? kNoIndex
+            : static_cast<std::uint16_t>(idx));
+
+    const auto gid = hit.geometryId();
+    detV->UnsafeAppend(m_cfg.detectorResolver(gid));
     volV->UnsafeAppend(static_cast<std::uint8_t>(gid.volume()));
     layV->UnsafeAppend(static_cast<std::uint16_t>(gid.layer()));
     surfV->UnsafeAppend(static_cast<std::uint32_t>(gid.sensitive()));
-    // The default `detectorResolver` reads the geometry id's `extra` byte,
-    // which geometry construction is expected to stamp with a per-surface
-    // subsystem id; users can swap in a custom resolver.
-    detV->UnsafeAppend(m_cfg.detectorResolver(gid));
-
-    // Open one inner list per measurement on each nested truth column.
-    check(pidVL->Append(), "open per-measurement particle_id list");
-    check(txVL->Append(), "open per-measurement true_x list");
-    check(tyVL->Append(), "open per-measurement true_y list");
-    check(tzVL->Append(), "open per-measurement true_z list");
-    check(timeVL->Append(), "open per-measurement time list");
-
-    // Reserve the nested inner value builders for this measurement's
-    // contributors, then append. (Unlike the flat builders we cannot reserve
-    // these up front because the per-measurement multiplicity is only known
-    // here; without the reserve, UnsafeAppend would write past the buffer.)
-    auto range = measToSimHits.equal_range(measIdx);
-    const auto nContribs =
-        static_cast<std::int64_t>(std::distance(range.first, range.second));
-    check(pidVV->Reserve(nContribs), "reserve particle_id contribs");
-    check(txVV->Reserve(nContribs), "reserve true_x contribs");
-    check(tyVV->Reserve(nContribs), "reserve true_y contribs");
-    check(tzVV->Reserve(nContribs), "reserve true_z contribs");
-    check(timeVV->Reserve(nContribs), "reserve time contribs");
-    for (auto it = range.first; it != range.second; ++it) {
-      const SimHitIndex simHitIdx = it->second;
-      const auto& hit = *simHits.nth(simHitIdx);
-      const auto& pos = hit.fourPosition();
-      txVV->UnsafeAppend(static_cast<float>(pos.x() / Acts::UnitConstants::mm));
-      tyVV->UnsafeAppend(static_cast<float>(pos.y() / Acts::UnitConstants::mm));
-      tzVV->UnsafeAppend(static_cast<float>(pos.z() / Acts::UnitConstants::mm));
-      timeVV->UnsafeAppend(
-          static_cast<float>(pos.w() / Acts::UnitConstants::mm));
-
-      std::uint64_t pid = kUnmatched;
-      if (particles != nullptr) {
-        auto pIt = particles->find(hit.particleId());
-        if (pIt != particles->end()) {
-          pid = static_cast<std::uint64_t>(
-              std::distance(particles->begin(), pIt));
-        }
-      }
-      pidVV->UnsafeAppend(pid);
-    }
   }
 
   auto finish = [](arrow::ListBuilder& b) {
@@ -312,9 +203,10 @@ ProcessCode ArrowSimHitOutputConverter::execute(
   };
 
   std::vector<std::shared_ptr<arrow::Array>> arrays = {
-      finish(xList),    finish(yList),   finish(zList),    finish(detList),
-      finish(volList),  finish(layList), finish(surfList), finish(pidList),
-      finish(txList),   finish(tyList),  finish(tzList),   finish(timeList),
+      finish(txList),  finish(tyList),  finish(tzList),  finish(ttList),
+      finish(tpxList), finish(tpyList), finish(tpzList), finish(teList),
+      finish(deList),  finish(pidList), finish(hidxList), finish(detList),
+      finish(volList), finish(layList), finish(surfList),
   };
 
   auto table =

--- a/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
+++ b/Plugins/Arrow/include/ActsPlugins/Arrow/ArrowUtil.hpp
@@ -145,9 +145,18 @@ ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> particleSchema();
 /// per event row instead of an opened list of N inner nulls.
 ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> trackSchema();
 
-/// Schema for the per-event simulated-hit table emitted by
-/// @c ArrowSimHitOutputConverter.
+/// Schema for the per-event TRUTH simulated-hit table emitted by
+/// @c ArrowSimHitOutputConverter: one entry per sim-hit (ALL sim-hits, in
+/// container order — the entry's position is the sim-hit id referenced by the
+/// measurement table's @c simhit_ids).
 ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> simHitSchema();
+
+/// Schema for the per-event RECO measurement table emitted by
+/// @c ArrowMeasurementOutputConverter: one entry per measurement (the entry's
+/// position is the measurement id referenced by track @c hit_ids), carrying
+/// the measured local parameters, cluster-shape features, and truth links
+/// (@c particle_ids and @c simhit_ids) into the particle / sim-hit tables.
+ACTS_ARROW_EXPORT std::shared_ptr<arrow::Schema> measurementSchema();
 
 /// Thin RAII wrapper around @c parquet::arrow::FileWriter that opens lazily
 /// on first write so the schema can be taken from the first event's table.

--- a/Plugins/Arrow/src/ArrowUtil.cpp
+++ b/Plugins/Arrow/src/ArrowUtil.cpp
@@ -211,13 +211,48 @@ std::shared_ptr<arrow::Schema> trackSchema() {
 }
 
 std::shared_ptr<arrow::Schema> simHitSchema() {
-  // One entry per MEASUREMENT (not per sim-hit). The entry's position in these
-  // per-event lists is the measurement's id, referenced by track hit_ids — so
-  // there is no separate measurement_id column. Reco x,y,z + geometry are one
-  // value per measurement; the contributing sim-hits' truth (particle_id,
-  // true_x/y/z, time) are nested lists (outer = per measurement, inner = per
-  // contributing sim-hit), mirroring the calo contrib_* columns.
+  // TRUTH table: one entry per sim-hit, ALL sim-hits in container order (the
+  // position is the sim-hit id referenced by the measurement table's
+  // simhit_ids). Standalone-complete so the simulation can be re-digitized
+  // from this table alone: position + time, the 4-momentum at the hit
+  // (before interaction), the deposited energy, the particle link, the hit's
+  // index along its particle trajectory, and the sensor identification.
   return arrow::schema({
+      arrow::field("true_x", arrow::list(arrow::float32()), false),
+      arrow::field("true_y", arrow::list(arrow::float32()), false),
+      arrow::field("true_z", arrow::list(arrow::float32()), false),
+      arrow::field("true_time", arrow::list(arrow::float32()), false),
+      arrow::field("tpx", arrow::list(arrow::float32()), false),
+      arrow::field("tpy", arrow::list(arrow::float32()), false),
+      arrow::field("tpz", arrow::list(arrow::float32()), false),
+      arrow::field("tE", arrow::list(arrow::float32()), false),
+      arrow::field("dE", arrow::list(arrow::float32()), false),
+      arrow::field("particle_id", arrow::list(arrow::uint64()), false),
+      arrow::field("hit_index", arrow::list(arrow::uint16()), false),
+      arrow::field("detector", arrow::list(arrow::uint8()), false),
+      arrow::field("volume_id", arrow::list(arrow::uint8()), false),
+      arrow::field("layer_id", arrow::list(arrow::uint16()), false),
+      arrow::field("surface_id", arrow::list(arrow::uint32()), false),
+  });
+}
+
+std::shared_ptr<arrow::Schema> measurementSchema() {
+  // RECO table: one entry per measurement (position in the per-event lists is
+  // the measurement id referenced by track hit_ids). Local parameters are
+  // always filled from the expanded full bound vector; the subspace bitmask
+  // (bit0 = loc0, bit1 = loc1, bit2 = time) says which were actually
+  // measured. Cluster-shape features come from the geometric digitization's
+  // Cluster objects. Truth is linked, not embedded: particle_ids are row
+  // indices into the particle table, simhit_ids row indices into the
+  // tracker_simhits table of the same event.
+  return arrow::schema({
+      arrow::field("loc0", arrow::list(arrow::float32()), false),
+      arrow::field("loc1", arrow::list(arrow::float32()), false),
+      arrow::field("var_loc0", arrow::list(arrow::float32()), false),
+      arrow::field("var_loc1", arrow::list(arrow::float32()), false),
+      arrow::field("time", arrow::list(arrow::float32()), false),
+      arrow::field("var_time", arrow::list(arrow::float32()), false),
+      arrow::field("subspace", arrow::list(arrow::uint8()), false),
       arrow::field("x", arrow::list(arrow::float32()), false),
       arrow::field("y", arrow::list(arrow::float32()), false),
       arrow::field("z", arrow::list(arrow::float32()), false),
@@ -225,12 +260,20 @@ std::shared_ptr<arrow::Schema> simHitSchema() {
       arrow::field("volume_id", arrow::list(arrow::uint8()), false),
       arrow::field("layer_id", arrow::list(arrow::uint16()), false),
       arrow::field("surface_id", arrow::list(arrow::uint32()), false),
-      arrow::field("particle_id", arrow::list(arrow::list(arrow::uint64())),
+      arrow::field("size_loc0", arrow::list(arrow::uint16()), false),
+      arrow::field("size_loc1", arrow::list(arrow::uint16()), false),
+      arrow::field("n_channels", arrow::list(arrow::uint16()), false),
+      arrow::field("sum_activation", arrow::list(arrow::float32()), false),
+      arrow::field("local_eta", arrow::list(arrow::float32()), false),
+      arrow::field("local_phi", arrow::list(arrow::float32()), false),
+      arrow::field("global_eta", arrow::list(arrow::float32()), false),
+      arrow::field("global_phi", arrow::list(arrow::float32()), false),
+      arrow::field("eta_angle", arrow::list(arrow::float32()), false),
+      arrow::field("phi_angle", arrow::list(arrow::float32()), false),
+      arrow::field("particle_ids", arrow::list(arrow::list(arrow::uint64())),
                    false),
-      arrow::field("true_x", arrow::list(arrow::list(arrow::float32())), false),
-      arrow::field("true_y", arrow::list(arrow::list(arrow::float32())), false),
-      arrow::field("true_z", arrow::list(arrow::list(arrow::float32())), false),
-      arrow::field("time", arrow::list(arrow::list(arrow::float32())), false),
+      arrow::field("simhit_ids", arrow::list(arrow::list(arrow::uint32())),
+                   false),
   });
 }
 

--- a/Python/Examples/src/plugins/Arrow.cpp
+++ b/Python/Examples/src/plugins/Arrow.cpp
@@ -7,6 +7,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "ActsExamples/Framework/IAlgorithm.hpp"
+#include "ActsExamples/Io/Arrow/ArrowMeasurementOutputConverter.hpp"
 #include "ActsExamples/Io/Arrow/ArrowParticleOutputConverter.hpp"
 #include "ActsExamples/Io/Arrow/ArrowSimHitOutputConverter.hpp"
 #include "ActsExamples/Io/Arrow/ArrowTrackOutputConverter.hpp"
@@ -65,8 +66,16 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsArrow, m) {
     auto [alg, c] =
         declareAlgorithm<ArrowSimHitOutputConverter, ArrowOutputConverter>(
             m, "ArrowSimHitOutputConverter");
-    ACTS_PYTHON_STRUCT(c, inputSimHits, inputParticles, inputMeasurements,
-                       inputSimHitMeasurementsMap, outputTable,
+    ACTS_PYTHON_STRUCT(c, inputSimHits, inputParticles, outputTable,
+                       detectorResolver);
+  }
+
+  {
+    auto [alg, c] = declareAlgorithm<ArrowMeasurementOutputConverter,
+                                     ArrowOutputConverter>(
+        m, "ArrowMeasurementOutputConverter");
+    ACTS_PYTHON_STRUCT(c, inputMeasurements, inputClusters, inputSimHits,
+                       inputParticles, inputSimHitMeasurementsMap, outputTable,
                        trackingGeometry, detectorResolver,
                        maxUnmatchedSimHitFraction);
   }

--- a/Python/Examples/tests/test_arrow.py
+++ b/Python/Examples/tests/test_arrow.py
@@ -429,6 +429,44 @@ def _read_dataset(directory: Path, expected_fields, expected_events: int):
     return _check
 
 
+def test_measurement_table_reco_only(tmp_path, fatras, trk_geo):
+    """The measurement converter runs without truth or clusters wired (data /
+    reco-only mode): link columns come out as empty lists, shape columns as
+    zeros, and the reco columns are unchanged."""
+    from acts.arrow import measurementSchema
+    from acts.examples.arrow import ArrowMeasurementOutputConverter, ParquetWriter
+
+    nevents = 2
+    s = Sequencer(numThreads=1, events=nevents)
+    fatras(s)
+    s.addAlgorithm(
+        ArrowMeasurementOutputConverter(
+            level=acts.logging.INFO,
+            inputMeasurements="measurements",
+            trackingGeometry=trk_geo,
+            outputTable="tracker_hits",
+        )
+    )
+    s.addWriter(
+        ParquetWriter(
+            level=acts.logging.INFO,
+            outputDir=str(tmp_path),
+            collections={"tracker_hits": "tracker_hits"},
+            expectedSchemas={"tracker_hits": measurementSchema()},
+        )
+    )
+    s.run()
+
+    table = _read_dataset(tmp_path / "tracker_hits", TRACKER_HITS_FIELDS, nevents)
+    loc0 = table.column("loc0").to_pylist()
+    simhit_ids = table.column("simhit_ids").to_pylist()
+    n_channels = table.column("n_channels").to_pylist()
+    assert sum(len(row) for row in loc0) > 0, "no measurements"
+    for ev_ids, ev_nch in zip(simhit_ids, n_channels):
+        assert all(len(ids) == 0 for ids in ev_ids), "links should be empty"
+        assert all(n == 0 for n in ev_nch), "shape should be zeros"
+
+
 def test_fatras_tracker_tables(tmp_path, fatras, trk_geo):
     """Fatras + digitization → the two tracker tables → Parquet.
 

--- a/Python/Examples/tests/test_arrow.py
+++ b/Python/Examples/tests/test_arrow.py
@@ -293,8 +293,15 @@ def test_particle_gun_fatras(tmp_path, fatras):
     _assert_particles_parquet(tmp_path / "particles_simulated_arrow", nevents)
 
 
-# Reco position + geometry are one value per measurement (flat list<scalar>).
-SIMHIT_FLAT_FIELDS = {
+# tracker_hits (RECO): one value per measurement (flat list<scalar>) ...
+TRACKER_HITS_FLAT_FIELDS = {
+    "loc0",
+    "loc1",
+    "var_loc0",
+    "var_loc1",
+    "time",
+    "var_time",
+    "subspace",
     "x",
     "y",
     "z",
@@ -302,46 +309,84 @@ SIMHIT_FLAT_FIELDS = {
     "volume_id",
     "layer_id",
     "surface_id",
+    "size_loc0",
+    "size_loc1",
+    "n_channels",
+    "sum_activation",
+    "local_eta",
+    "local_phi",
+    "global_eta",
+    "global_phi",
+    "eta_angle",
+    "phi_angle",
 }
-# Contributing sim-hits' truth is nested per measurement (list<list<scalar>>).
-SIMHIT_NESTED_FIELDS = {
-    "particle_id",
+# ... plus the nested truth LINKS (list<list<scalar>>): row indices into the
+# particle table and the tracker_simhits table respectively.
+TRACKER_HITS_NESTED_FIELDS = {
+    "particle_ids",
+    "simhit_ids",
+}
+TRACKER_HITS_FIELDS = TRACKER_HITS_FLAT_FIELDS | TRACKER_HITS_NESTED_FIELDS
+
+# tracker_simhits (TRUTH): one value per sim-hit, ALL sim-hits, flat columns.
+TRACKER_SIMHITS_FIELDS = {
     "true_x",
     "true_y",
     "true_z",
-    "time",
+    "true_time",
+    "tpx",
+    "tpy",
+    "tpz",
+    "tE",
+    "dE",
+    "particle_id",
+    "hit_index",
+    "detector",
+    "volume_id",
+    "layer_id",
+    "surface_id",
 }
-SIMHIT_FIELDS = SIMHIT_FLAT_FIELDS | SIMHIT_NESTED_FIELDS
 
 
-def _add_simhit_arrow_writer(
+def _add_tracker_arrow_writers(
     s: Sequencer,
     outputDir: Path,
     trackingGeometry,
-    table_key: str = "simhits_arrow",
     *,
     eventsPerShard: int = 2,
 ) -> None:
-    """Wire an ArrowSimHitOutputConverter + ParquetWriter for the simhits.
+    """Wire the two tracker-table converters + one ParquetWriter.
 
-    The converter emits one row per measurement: reco x,y,z (projected from the
-    measurement's bound parameters through its surface) and geometry once per
-    measurement, with the contributing sim-hits' truth as nested lists. It needs
-    the measurement container, the sim-hit→measurement map, and the tracking
-    geometry — all produced/owned by the fatras+digitization fixture.
+    `ArrowSimHitOutputConverter` emits the TRUTH table (one row per sim-hit,
+    ALL sim-hits); `ArrowMeasurementOutputConverter` emits the RECO table (one
+    row per measurement) whose `simhit_ids` index the truth table. Both need
+    collections produced/owned by the fatras+digitization fixture.
     """
-    from acts.arrow import simHitSchema
-    from acts.examples.arrow import ArrowSimHitOutputConverter, ParquetWriter
+    from acts.arrow import measurementSchema, simHitSchema
+    from acts.examples.arrow import (
+        ArrowMeasurementOutputConverter,
+        ArrowSimHitOutputConverter,
+        ParquetWriter,
+    )
 
     s.addAlgorithm(
         ArrowSimHitOutputConverter(
             level=acts.logging.INFO,
             inputSimHits="simhits",
             inputParticles="particles_simulated",
+            outputTable="tracker_simhits",
+        )
+    )
+    s.addAlgorithm(
+        ArrowMeasurementOutputConverter(
+            level=acts.logging.INFO,
             inputMeasurements="measurements",
+            inputClusters="clusters",
+            inputSimHits="simhits",
+            inputParticles="particles_simulated",
             inputSimHitMeasurementsMap="simhit_measurements_map",
             trackingGeometry=trackingGeometry,
-            outputTable=table_key,
+            outputTable="tracker_hits",
         )
     )
 
@@ -349,106 +394,109 @@ def _add_simhit_arrow_writer(
         ParquetWriter(
             level=acts.logging.INFO,
             outputDir=str(outputDir),
-            collections={table_key: table_key},
-            expectedSchemas={table_key: simHitSchema()},
+            collections={
+                "tracker_hits": "tracker_hits",
+                "tracker_simhits": "tracker_simhits",
+            },
+            expectedSchemas={
+                "tracker_hits": measurementSchema(),
+                "tracker_simhits": simHitSchema(),
+            },
             eventsPerShard=eventsPerShard,
         )
     )
 
 
-def _assert_simhits_parquet(directory: Path, expected_events: int) -> None:
-    """Verify a simhits dataset directory: schema shape (flat reco vs nested
-    truth), row count, and measurement-row semantics.
-
-    One row per event; within an event one entry per measurement. Reco x,y,z are
-    flat (one per measurement) and finite; the contributing sim-hits' truth is
-    nested (outer per measurement, inner per contributing sim-hit) and finite.
-    """
+def _read_dataset(directory: Path, expected_fields, expected_events: int):
     assert directory.exists(), f"{directory} does not exist"
-    assert directory.is_dir(), f"{directory} is not a directory"
-
     fragments = sorted(directory.glob("*.parquet"))
     assert fragments, f"{directory} contains no parquet shards"
-    for f in fragments:
-        assert f.stat().st_size > 0, f"{f} is empty"
 
     @with_pyarrow
     def _check(pa, pq):
-        first_schema = pq.ParquetFile(str(fragments[0])).schema_arrow
-        names = {first_schema.field(i).name for i in range(len(first_schema))}
+        schema = pq.ParquetFile(str(fragments[0])).schema_arrow
+        names = {schema.field(i).name for i in range(len(schema))}
         assert "event_id" in names, f"{directory.name}: event_id column missing"
-        missing = SIMHIT_FIELDS - names
+        missing = expected_fields - names
         assert not missing, f"{directory.name}: missing fields {missing}"
-        # The row index is the measurement id, so there must be no id column.
-        assert (
-            "measurement_id" not in names
-        ), f"{directory.name}: measurement_id column should not exist (row index is the id)"
-
-        # Reco + geometry are flat list<scalar>; truth is nested list<list<scalar>>.
-        for field_name in SIMHIT_FLAT_FIELDS:
-            ftype = first_schema.field(field_name).type
-            assert pa.types.is_list(ftype) and not pa.types.is_list(
-                ftype.value_type
-            ), f"{directory.name}: '{field_name}' should be flat list, got {ftype}"
-        for field_name in SIMHIT_NESTED_FIELDS:
-            ftype = first_schema.field(field_name).type
-            assert pa.types.is_list(ftype) and pa.types.is_list(
-                ftype.value_type
-            ), f"{directory.name}: '{field_name}' should be nested list<list>, got {ftype}"
-
         table = pq.ParquetDataset(str(directory)).read()
         assert table.num_rows == expected_events, (
             f"{directory.name}: expected {expected_events} events, "
             f"got {table.num_rows}"
         )
+        return table
 
-        x = table.column("x").to_pylist()
-        y = table.column("y").to_pylist()
-        z = table.column("z").to_pylist()
-        tx = table.column("true_x").to_pylist()
-
-        total_meas = sum(len(row) for row in x)
-        assert total_meas > 0, f"{directory.name}: no measurements across any event"
-
-        for ex, ey, ez, etx in zip(x, y, z, tx):
-            # Reco rows and the nested truth must align one-to-one per measurement.
-            assert (
-                len(ex) == len(etx)
-            ), f"{directory.name}: {len(ex)} reco rows vs {len(etx)} truth rows"
-            for xv, yv, zv in zip(ex, ey, ez):
-                # Reco position is always computed for a measurement — finite,
-                # and inside the generic-detector envelope (mm). A units
-                # regression (m vs mm) or stale position would blow past this.
-                assert (
-                    math.isfinite(xv) and math.isfinite(yv) and math.isfinite(zv)
-                ), f"{directory.name}: non-finite reco pos ({xv},{yv},{zv})"
-                r = math.hypot(xv, yv)
-                assert r < 1500.0 and abs(zv) < 4000.0, (
-                    f"{directory.name}: reco pos ({xv},{yv},{zv}) outside "
-                    f"detector envelope — units or stale-position regression?"
-                )
-            # Every measurement carries at least one contributing sim-hit (the
-            # truth-only ones are dropped), and their truth must be finite.
-            for contribs in etx:
-                assert (
-                    len(contribs) >= 1
-                ), f"{directory.name}: measurement with no contributing sim-hit"
-                for v in contribs:
-                    assert math.isfinite(v), f"{directory.name}: non-finite truth {v}"
+    return _check
 
 
-def test_fatras_simhits_measurement_rows(tmp_path, fatras, trk_geo):
-    """Fatras + digitization → ArrowSimHitOutputConverter emits one row per
-    measurement with reco x,y,z (finite, in-envelope) and nested per-measurement
-    truth → Parquet. `trk_geo` is the same geometry the fixture digitizes
-    against, so surface lookups resolve."""
+def test_fatras_tracker_tables(tmp_path, fatras, trk_geo):
+    """Fatras + digitization → the two tracker tables → Parquet.
+
+    Checks the sim/reco split contract: the truth table holds ALL sim-hits
+    (flat columns, finite momentum/deposit); the reco table holds one entry
+    per measurement with always-filled local parameters + a subspace bitmask,
+    finite in-envelope global positions, and truth LINKS whose simhit_ids
+    resolve into the truth table and whose particle_ids agree with the linked
+    sim-hits' particle column.
+    """
     nevents = 3
     s = Sequencer(numThreads=1, events=nevents)
     fatras(s)
-    _add_simhit_arrow_writer(s, tmp_path, trk_geo)
+    _add_tracker_arrow_writers(s, tmp_path, trk_geo)
     s.run()
 
-    _assert_simhits_parquet(tmp_path / "simhits_arrow", nevents)
+    hits_t = _read_dataset(
+        tmp_path / "tracker_hits", TRACKER_HITS_FIELDS, nevents
+    )
+    sim_t = _read_dataset(
+        tmp_path / "tracker_simhits", TRACKER_SIMHITS_FIELDS, nevents
+    )
+
+    hits = {name: hits_t.column(name).to_pylist() for name in TRACKER_HITS_FIELDS}
+    sims = {
+        name: sim_t.column(name).to_pylist() for name in TRACKER_SIMHITS_FIELDS
+    }
+
+    total_meas = sum(len(row) for row in hits["x"])
+    total_sims = sum(len(row) for row in sims["true_x"])
+    assert total_meas > 0, "no measurements across any event"
+    assert total_sims >= total_meas, "fewer sim-hits than measurements"
+
+    for ev in range(nevents):
+        n_sim = len(sims["true_x"][ev])
+        # Truth table: finite positions and momenta; deposits non-negative.
+        for i in range(n_sim):
+            for col in ("true_x", "true_y", "true_z", "tpx", "tpy", "tpz", "tE"):
+                assert math.isfinite(sims[col][ev][i]), f"non-finite {col}"
+            assert sims["dE"][ev][i] >= 0.0, "negative energy deposit"
+
+        n_meas = len(hits["x"][ev])
+        for m in range(n_meas):
+            # Reco position finite and inside the generic-detector envelope.
+            xv, yv, zv = hits["x"][ev][m], hits["y"][ev][m], hits["z"][ev][m]
+            assert math.isfinite(xv) and math.isfinite(yv) and math.isfinite(zv)
+            assert math.hypot(xv, yv) < 1500.0 and abs(zv) < 4000.0, (
+                f"reco pos ({xv},{yv},{zv}) outside envelope - units regression?"
+            )
+            # Local parameters always filled; the subspace bitmask says which
+            # components were actually measured (and must measure something).
+            assert math.isfinite(hits["loc0"][ev][m])
+            assert math.isfinite(hits["loc1"][ev][m])
+            assert hits["subspace"][ev][m] & 0x3, "no local component measured"
+
+            # Truth links: at least one contributor, ids resolve into the
+            # truth table, and the linked particles agree between the tables.
+            simhit_ids = hits["simhit_ids"][ev][m]
+            particle_ids = hits["particle_ids"][ev][m]
+            assert len(simhit_ids) >= 1, "measurement with no contributing sim-hit"
+            assert len(simhit_ids) == len(particle_ids)
+            for sid, pid in zip(simhit_ids, particle_ids):
+                assert sid < n_sim, f"simhit_id {sid} out of range ({n_sim})"
+                assert sims["particle_id"][ev][sid] == pid, (
+                    "particle_ids disagree between tracker_hits and "
+                    "tracker_simhits for the same contributor"
+                )
+
 
 
 @pytest.mark.skipif(not pythia8Enabled, reason="Pythia8 not built")

--- a/Python/Plugins/src/Arrow.cpp
+++ b/Python/Plugins/src/Arrow.cpp
@@ -234,5 +234,9 @@ PYBIND11_MODULE(ActsPluginsPythonBindingsArrow, m) {
       "Schema produced by ArrowTrackOutputConverter.");
   m.def(
       "simHitSchema", [wrap]() { return wrap(ArrowUtil::simHitSchema()); },
-      "Schema produced by ArrowSimHitOutputConverter.");
+      "Schema produced by ArrowSimHitOutputConverter (truth tracker_simhits).");
+  m.def(
+      "measurementSchema",
+      [wrap]() { return wrap(ArrowUtil::measurementSchema()); },
+      "Schema produced by ArrowMeasurementOutputConverter (reco tracker_hits).");
 }


### PR DESCRIPTION
Implements the sim/reco split agreed with Benjamin + Andreas (2026-06-12):

- **`tracker_simhits`** (ArrowSimHitOutputConverter reworked): one row per sim-hit, ALL sim-hits in container order — `true_x/y/z/time`, `tpx/tpy/tpz/tE` (momentum4Before), `dE`, `particle_id` (particle-table row), `hit_index`, sensor ids. Standalone-complete for re-digitization.
- **`tracker_hits`** (new ArrowMeasurementOutputConverter): one row per measurement (row index = the id referenced by track `hit_ids`) — `loc0/loc1` + variances always expanded to the full bound layout with a `subspace` bitmask (bit0/1/2 = loc0/loc1/time measured), measured time, reco global x/y/z, sensor ids, cluster-shape columns (sizes, n_channels, sum_activation, local/global η-φ, incidence angles), and truth **links only**: `particle_ids` + `simhit_ids`. Unmatched-sim-hit fraction is a warning-only diagnostic.
- Python bindings + `measurementSchema()`; `test_arrow.py` rewritten with the two-table contract test.

**Validated** (colliderml-production regression harness, ODD):
- μ=10 higgs_portal: 16 passed / 8 documented skips / 1 xfail.
- μ=200 ttbar (5 events): ~195–268k measurements/event, sim/meas = 1.022, **merged measurements ≈ 1.95%** (multi-contributor — merging verifiably ON), orphan sim-hits ≤ 0.006%, 100% `simhit_ids` resolution, particle links agree contributor-by-contributor between the tables; 30.8 GB RSS, ~34 s/event digi+reco at 16 threads.

**Known open items**:
1. Cluster-shape columns currently come out all-zero: clusters reach the converter without channel content even with geometric digitization (pre-existing; reproduced on this branch and on the old fork; the contract test xfails with a pointed message). Needs the digitization channel-content question answered before the shape columns are real.
2. Rebase dropped three fork features that downstream code feature-detects around: the #5441 calo machinery, `outputMCParticleMap`, and the tracksummary `measurementIDs` branch (v1-comparison tests skip when absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)